### PR TITLE
Fix conformer alignment using SDF

### DIFF
--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -31,6 +31,7 @@ sequences:
         sequence: SEQUENCE    # only for protein, dna, rna
         smiles: SMILES        # only for ligand, exclusive with ccd
         ccd: CCD              # only for ligand, exclusive with smiles
+        conformer: PATH       # optional ligand conformer file (SDF, MOL2 or PDB)
         msa: MSA_PATH         # only for protein
         modifications:
           - position: RES_IDX   # index of residue, starting from 1
@@ -46,8 +47,9 @@ constraints:
     - pocket:
         binder: CHAIN_ID
         contacts: [[CHAIN_ID, RES_IDX], [CHAIN_ID, RES_IDX]]
+sample_ligand_conformation: true   # optional, set to false to keep ligand fixed
 ```
-`sequences` has one entry for every unique chain/molecule in the input. Each polymer entity as a `ENTITY_TYPE`  either `protein`, `dna` or`rna` and have a `sequence` attribute. Non-polymer entities are indicated by `ENTITY_TYPE` equal to `ligand` and have a `smiles` or `ccd` attribute. `CHAIN_ID` is the unique identifier for each chain/molecule, and it should be set as a list in case of multiple identical entities in the structure. For proteins, the `msa` key is required by default but can be ommited by passing the `--use_msa_server` flag which will auto-generate the MSA using the mmseqs2 server. If you wish to use a precomputed MSA, use the `msa` attribute with `MSA_PATH` indicating the path to the `.a3m` file containing the MSA for that protein. If you wish to explicitly run single sequence mode (which is generally advised against as it will hurt model performance), you may do so by using the special keyword `empty` for that protein (ex: `msa: empty`).
+`sequences` has one entry for every unique chain/molecule in the input. Each polymer entity as a `ENTITY_TYPE`  either `protein`, `dna` or `rna` and have a `sequence` attribute. Non-polymer entities are indicated by `ENTITY_TYPE` equal to `ligand` and have a `smiles`, `ccd` or `conformer` attribute. `CHAIN_ID` is the unique identifier for each chain/molecule, and it should be set as a list in case of multiple identical entities in the structure. For proteins, the `msa` key is required by default but can be ommited by passing the `--use_msa_server` flag which will auto-generate the MSA using the mmseqs2 server. If you wish to use a precomputed MSA, use the `msa` attribute with `MSA_PATH` indicating the path to the `.a3m` file containing the MSA for that protein. If you wish to explicitly run single sequence mode (which is generally advised against as it will hurt model performance), you may do so by using the special keyword `empty` for that protein (ex: `msa: empty`).
 
 The `modifications` field is an optional field that allows you to specify modified residues in the polymer (`protein`, `dna` or`rna`). The `position` field specifies the index (starting from 1) of the residue, and `ccd` is the CCD code of the modified residue. This field is currently only supported for CCD ligands.
 
@@ -67,7 +69,8 @@ sequences:
       ccd: SAH
   - ligand:
       id: [E, F]
-      smiles: N[C@@H](Cc1ccc(O)cc1)C(=O)O
+      conformer: ./ligand.sdf
+sample_ligand_conformation: false
 ```
 
 

--- a/src/boltz/data/types.py
+++ b/src/boltz/data/types.py
@@ -372,6 +372,7 @@ class Record(JSONSerializable):
     structure: StructureInfo
     chains: list[ChainInfo]
     interfaces: list[InterfaceInfo]
+    sample_ligand_conformation: bool = True
 
 
 ####################################################################################################

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -52,6 +52,7 @@ class BoltzDiffusionParams:
     alignment_reverse_diff: bool = True
     synchronize_sigmas: bool = True
     use_inference_model_cache: bool = True
+    sample_ligand_conformation: bool = True
 
 
 @rank_zero_only
@@ -475,12 +476,20 @@ def predict(
         "sampling_steps": sampling_steps,
         "diffusion_samples": diffusion_samples,
     }
+    sample_ligand = True
+    if processed.manifest.records:
+        sample_ligand = processed.manifest.records[0].sample_ligand_conformation
+
+    diffusion_params = asdict(
+        BoltzDiffusionParams(sample_ligand_conformation=sample_ligand)
+    )
+
     model_module: Boltz1 = Boltz1.load_from_checkpoint(
         checkpoint,
         strict=True,
         predict_args=predict_args,
         map_location="cpu",
-        diffusion_process_args=asdict(BoltzDiffusionParams()),
+        diffusion_process_args=diffusion_params,
     )
     model_module.eval()
 

--- a/src/boltz/model/modules/diffusion.py
+++ b/src/boltz/model/modules/diffusion.py
@@ -303,6 +303,7 @@ class AtomDiffusion(Module):
         synchronize_sigmas=False,
         use_inference_model_cache=False,
         accumulate_token_repr=False,
+        sample_ligand_conformation=True,
         **kwargs,
     ):
         """Initialize the atom diffusion module.
@@ -345,6 +346,8 @@ class AtomDiffusion(Module):
             Whether to use the inference model cache, by default False.
         accumulate_token_repr : bool, optional
             Whether to accumulate the token representation, by default False.
+        sample_ligand_conformation : bool, optional
+            Whether to sample ligand conformations during diffusion, by default True.
 
         """
         super().__init__()
@@ -372,6 +375,7 @@ class AtomDiffusion(Module):
         self.alignment_reverse_diff = alignment_reverse_diff
         self.synchronize_sigmas = synchronize_sigmas
         self.use_inference_model_cache = use_inference_model_cache
+        self.sample_ligand_conformation = sample_ligand_conformation
 
         self.accumulate_token_repr = accumulate_token_repr
         self.token_s = score_model_args["token_s"]
@@ -465,7 +469,28 @@ class AtomDiffusion(Module):
 
         # atom position is noise at the beginning
         init_sigma = sigmas[0]
-        atom_coords = init_sigma * torch.randn(shape, device=self.device)
+
+        feats = network_condition_kwargs.get("feats")
+        ligand_mask = None
+        if (not self.sample_ligand_conformation) and (feats is not None):
+            orig_coords = feats["coords"].repeat_interleave(multiplicity, 0)
+            ligand_mask = (
+                torch.bmm(
+                    feats["atom_to_token"].float(),
+                    feats["mol_type"].unsqueeze(-1).float(),
+                )
+                .squeeze(-1)
+                .long()
+            )
+            ligand_mask = ligand_mask == const.chain_type_ids["NONPOLYMER"]
+            ligand_mask = ligand_mask.repeat_interleave(multiplicity, 0)
+
+            atom_coords = init_sigma * torch.randn(shape, device=self.device)
+            atom_coords = atom_coords * (
+                ~ligand_mask.unsqueeze(-1)
+            ) + orig_coords * ligand_mask.unsqueeze(-1)
+        else:
+            atom_coords = init_sigma * torch.randn(shape, device=self.device)
         atom_coords_denoised = None
         model_cache = {} if self.use_inference_model_cache else None
 
@@ -490,6 +515,8 @@ class AtomDiffusion(Module):
                 * sqrt(t_hat**2 - sigma_tm**2)
                 * torch.randn(shape, device=self.device)
             )
+            if (ligand_mask is not None) and (not self.sample_ligand_conformation):
+                eps = eps * (~ligand_mask.unsqueeze(-1))
             atom_coords_noisy = atom_coords + eps
 
             with torch.no_grad():
@@ -535,6 +562,11 @@ class AtomDiffusion(Module):
                 + self.step_scale * (sigma_t - t_hat) * denoised_over_sigma
             )
 
+            if (ligand_mask is not None) and (not self.sample_ligand_conformation):
+                atom_coords_next = atom_coords_next * (
+                    ~ligand_mask.unsqueeze(-1)
+                ) + atom_coords * ligand_mask.unsqueeze(-1)
+
             atom_coords = atom_coords_next
 
         return dict(sample_atom_coords=atom_coords, diff_token_repr=token_repr)
@@ -571,10 +603,7 @@ class AtomDiffusion(Module):
             sigmas = self.noise_distribution(batch_size * multiplicity)
         padded_sigmas = rearrange(sigmas, "b -> b 1 1")
 
-        atom_coords = feats["coords"]
-        B, N, L = atom_coords.shape[0:3]
-        atom_coords = atom_coords.reshape(B * N, L, 3)
-        atom_coords = atom_coords.repeat_interleave(multiplicity // N, 0)
+        atom_coords = feats["coords"].repeat_interleave(multiplicity, 0)
         feats["coords"] = atom_coords
 
         atom_mask = feats["atom_pad_mask"]


### PR DESCRIPTION
## Summary
- keep stereochemistry when matching input SDF conformers
- handle ligand conformer freezing without mis-shaping tensors
- minor formatting adjustments

## Testing
- `ruff format src/boltz/model/modules/diffusion.py src/boltz/data/parse/schema.py src/boltz/data/types.py src/boltz/main.py`
- `ruff check src/boltz/model/modules/diffusion.py src/boltz/data/parse/schema.py src/boltz/data/types.py src/boltz/main.py`
- `pytest -q` (no tests were found)


------
https://chatgpt.com/codex/tasks/task_e_684145cf28f883269576929e3ad122fe